### PR TITLE
[FEAT/15] 공고 상세 페이지 레이아웃 완성  

### DIFF
--- a/src/features/specific/components/AnnouncementQuestion.tsx
+++ b/src/features/specific/components/AnnouncementQuestion.tsx
@@ -1,0 +1,14 @@
+export const AnnouncementQuestion = () => {
+  return (
+    <div className="flex w-full items-center gap-3">
+      <div className="bg-admin-box flex h-9 w-28 items-center justify-between rounded-[10px] px-3.5 py-2.5">
+        <div className="justify-start text-sm font-medium text-[#5A5A5A]">
+          순서
+        </div>
+      </div>
+      <div className="bg-admin-box flex h-9 w-full items-center rounded-[10px] px-7.5 py-2.5 text-base font-medium text-white">
+        멋쟁이사자처럼 강남대학교에 어떤 계기로 지원하게 되었나요?
+      </div>
+    </div>
+  );
+};

--- a/src/features/specific/pages/AdminSpecificAnnouncementPage.tsx
+++ b/src/features/specific/pages/AdminSpecificAnnouncementPage.tsx
@@ -8,21 +8,7 @@ import AdminStateButton from "@specific/components/AdminStatusButton";
 import AnnouncementButton from "@specific/components/AnnouncementCardButton";
 import AnnouncementDateText from "@specific/components/AnnouncementDateText";
 import { AnnouncementDelete } from "@specific/components/AnnouncementDelete";
-
-const AnnouncementQuestion = () => {
-  return (
-    <div className="flex w-full items-center gap-3">
-      <div className="bg-admin-box flex h-9 w-28 items-center justify-between rounded-[10px] px-3.5 py-2.5">
-        <div className="justify-start text-sm font-medium text-[#5A5A5A]">
-          순서
-        </div>
-      </div>
-      <div className="bg-admin-box flex h-9 w-full items-center rounded-[10px] px-7.5 py-2.5 text-base font-medium text-white">
-        멋쟁이사자처럼 강남대학교에 어떤 계기로 지원하게 되었나요?
-      </div>
-    </div>
-  );
-};
+import { AnnouncementQuestion } from "@specific/components/AnnouncementQuestion";
 
 interface AnnouncementTitleTextProps {
   text: string;


### PR DESCRIPTION
## 🔗 관련 Issue

- 15 번


## ✨ 작업 내용
공고 상세 페이지 레이아웃 완성  
- 
- 

## 📦 추가 / 변경된 라이브러리

-
- 


## ⚠️ 리뷰 참고 사항

- 
- 
