### PR TITLE
공고관리 페이지 라우팅 연결

### DIFF
--- a/src/features/specific/components/modal/SpecificDetailmodal.tsx
+++ b/src/features/specific/components/modal/SpecificDetailmodal.tsx
@@ -104,7 +104,10 @@ export default function SpecificDetailModal({
     >
       {/* 웹 */}
       <div className="hidden md:block">
-        <Modal>
+        <div
+          className="border-admin-outline-2 bg-admin-background text-admin-white fixed top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-[10px] border"
+          style={{ zIndex: 201, width: 682, height: "calc(100vh - 40px)" }}
+        >
           {/* 모달 헤더 */}
           <Modal.TextLayout>
             <Modal.Title onClick={onClose}>
@@ -120,10 +123,7 @@ export default function SpecificDetailModal({
           </Modal.TextLayout>
 
           {/* 기본 정보 + 질문/답변 영역 */}
-          <div
-            className="overflow-y-scroll px-5 pt-6"
-            style={{ maxHeight: "calc(100vh - 320px)" }}
-          >
+          <div className="flex-1 overflow-y-auto px-5 pt-6">
             {/*api*/}
             {isLoading && (
               <p className="text-admin-sub py-16 text-center text-sm font-medium">
@@ -175,7 +175,7 @@ export default function SpecificDetailModal({
               <Button onClick={onClose}>완료</Button>
             </div>
           </div>
-        </Modal>
+        </div>
       </div>
 
       {/* 모바일 */}

--- a/src/features/status/pages/AdminAnnouncementManagementPage.tsx
+++ b/src/features/status/pages/AdminAnnouncementManagementPage.tsx
@@ -118,6 +118,7 @@ function AdminAnnouncementManagementPage() {
                 <button
                   type="button"
                   className={MOBILE_NEW_ANNOUNCEMENT_BUTTON_CLASS}
+                  onClick={() => navigate("/admin/announcements/create")}
                 >
                   새 공고 등록
                 </button>
@@ -198,6 +199,7 @@ function AdminAnnouncementManagementPage() {
                   <button
                     type="button"
                     className={WEB_NEW_ANNOUNCEMENT_BUTTON_CLASS}
+                    onClick={() => navigate("/admin/announcements/create")}
                   >
                     새 공고 등록
                   </button>


### PR DESCRIPTION
- 공고관리 페이지 새 공고 등록 버튼을 /admin/announcements/create로 연결
- 모달 레이아웃 폭 수정

## 🔗 관련 Issue

- 이슈 번호


## ✨ 작업 내용

- 
- 

## 📦 추가 / 변경된 라이브러리

-
- 


## ⚠️ 리뷰 참고 사항

- 
- 
